### PR TITLE
More robustly handle sample names in indel VCF headers

### DIFF
--- a/deTiN/deTiN_utilities.py
+++ b/deTiN/deTiN_utilities.py
@@ -543,6 +543,10 @@ def read_indel_vcf(vcf,seg_table,indel_type):
      10: headerline[10]
     }, inplace = True)
 
+    # determine which columns corresponds to the tumor/normal
+    t_samp_ix = indel_table.columns.get_loc(tumor_sample)
+    n_samp_ix = indel_table.columns.get_loc(normal_sample)
+
     if indel_type.lower() == 'strelka':
         counts_format = indel_table['format'][0].split(':')
         depth_ix = counts_format.index('DP')
@@ -577,8 +581,8 @@ def read_indel_vcf(vcf,seg_table,indel_type):
     t_ref_count = np.zeros([len(indel_table), 1])
 
     for index, row in indel_table.iterrows():
-        spl_n = row['normal'].split(':')
-        spl_t = row['tumor'].split(':')
+        spl_n = row.iloc[n_samp_ix].split(':')
+        spl_t = row.iloc[t_samp_ix].split(':')
         if indel_type.lower() == 'strelka':
             n_depth[index] = int(spl_n[depth_ix])
             n_alt_count[index] = int(spl_n[alt_indel_ix].split(',')[0])

--- a/deTiN/deTiN_utilities.py
+++ b/deTiN/deTiN_utilities.py
@@ -544,8 +544,23 @@ def read_indel_vcf(vcf,seg_table,indel_type):
     }, inplace = True)
 
     # determine which columns corresponds to the tumor/normal
-    t_samp_ix = indel_table.columns.get_loc(tumor_sample)
-    n_samp_ix = indel_table.columns.get_loc(normal_sample)
+    # if the sample names don't match the column names, we assume it's because
+    # we set it to generic "tumor"/"normal" (lowercase) but the column name is
+    # capitalized. if this assumption isn't satisfied, then we fail.
+    try:
+        t_samp_ix = indel_table.columns.get_loc(tumor_sample)
+    except KeyError:
+        if "TUMOR" in indel_table.columns:
+            t_samp_ix = indel_table.columns.get_loc("TUMOR")
+        else:
+            raise KeyError("Could not infer which VCF column corresponds to the tumor!")
+    try:
+        n_samp_ix = indel_table.columns.get_loc(normal_sample)
+    except KeyError:
+        if "NORMAL" in indel_table.columns:
+            n_samp_ix = indel_table.columns.get_loc("NORMAL")
+        else:
+            raise KeyError("Could not infer which VCF column corresponds to the normal!")
 
     if indel_type.lower() == 'strelka':
         counts_format = indel_table['format'][0].split(':')

--- a/deTiN/deTiN_utilities.py
+++ b/deTiN/deTiN_utilities.py
@@ -525,13 +525,25 @@ def read_indel_vcf(vcf,seg_table,indel_type):
         if line[0:14] == '##tumor_sample':
             tumor_sample = line.split('=')[1][0:-1]
         if line[0] == '#' and line[1] != '#':
-            headerline = line.split('\t')
+            headerline = line.rstrip().split('\t')
             break
 
+    indel_table = pd.read_csv(vcf, sep='\t', comment='#', header=None, low_memory=False, dtype=cols_type)
+    indel_table.rename(columns = {
+      0: 'contig',
+      1: 'position',
+      2: 'ID',
+      3: 'REF',
+      4: 'ALT',
+      5: 'QUAL',
+      6: 'filter',
+      7: 'INFO',
+      8: 'format',
+      9: headerline[9],
+     10: headerline[10]
+    }, inplace = True)
+
     if indel_type.lower() == 'strelka':
-        indel_table = pd.read_csv(vcf, sep='\t', comment='#', header=None, low_memory=False, dtype=cols_type)
-        indel_table.rename(columns={0: 'contig', 1: 'position',2:'ID',3:'REF',4:'ALT',5:'QUAL',7:'INFO', 8: 'format', 6: 'filter', 9: headerline[9].lower(), 10: headerline[10][0:-1].lower()},
-                       inplace=True)
         counts_format = indel_table['format'][0].split(':')
         depth_ix = counts_format.index('DP')
         alt_indel_ix = counts_format.index('TIR')
@@ -540,37 +552,12 @@ def read_indel_vcf(vcf,seg_table,indel_type):
         indel_table.reset_index(inplace=True, drop=True)
 
     elif indel_type.lower() == 'mutect2':
-        indel_table = pd.read_csv(vcf, sep='\t', comment='#', header=None, low_memory=False, dtype=cols_type)
-        # CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TUMOR	NORMAL
-        if tumor_sample == 'tumor' and normal_sample == 'normal':
-            indel_table.rename(
-                columns={0: 'contig', 1: 'position', 2: 'ID', 3: 'REF', 4: 'ALT', 5: 'QUAL', 7: 'INFO', 8: 'format',
-                         6: 'filter', 9: 'tumor', 10: 'normal'},
-                inplace=True)
-        else:
-            if tumor_sample == headerline[9]:
-                indel_table.rename(
-                        columns={0: 'contig', 1: 'position', 2: 'ID', 3: 'REF', 4: 'ALT', 5: 'QUAL', 7: 'INFO', 8: 'format',
-                         6: 'filter', 9: 'tumor', 10: 'normal'},
-                        inplace=True)
-            elif tumor_sample == headerline[10][0:-1]:
-                indel_table.rename(
-                    columns={0: 'contig', 1: 'position', 2: 'ID', 3: 'REF', 4: 'ALT', 5: 'QUAL', 7: 'INFO', 8: 'format',
-                             6: 'filter', 9: 'normal', 10: 'tumor'},
-                    inplace=True)
-            else:
-                print('failed to read MuTect 2 indels VCF')
-                sys.exit()
         counts_format = indel_table['format'][0].split(':')
         depth_ix = counts_format.index('AD')
         indel_table = indel_table[np.isfinite(is_member(indel_table['filter'], ['PASS', 'alt_allele_in_normal','artifact_in_normal']))]
         indel_table.reset_index(inplace=True, drop=True)
 
     elif indel_type.lower() == 'sanger':
-        indel_table = pd.read_csv(vcf, sep='\t', comment='#', header=None, low_memory=False, dtype=cols_type)
-        # CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  NORMAL  TUMOUR
-        indel_table.rename(columns={0: 'contig', 1: 'position',2:'ID',3:'REF',4:'ALT',5:'QUAL',7:'INFO',8: 'format', 6: 'filter', 9: headerline[9].lower(), 10: headerline[10][0:-1].lower()},
-                           inplace=True)
         b1 = np.logical_or.reduce([indel_table['filter'] == 'F012', indel_table['filter'] == 'F012;F015'])
         b2 = np.logical_or.reduce([indel_table['filter'] == 'PASS', indel_table['filter'] == 'F015'])
         indel_table = indel_table[np.logical_or.reduce([b1, b2])]
@@ -614,7 +601,7 @@ def read_indel_vcf(vcf,seg_table,indel_type):
             t_alt_count[index] = np.sum([int(spl_t[i]) for i in alt_count_idx])
             t_ref_count[index] = t_depth[index] - t_alt_count[index]
     if len(indel_table) == 0:
-        indel_table = pd.DataFrame(index=[0],columns=['contig', 'position','ID','REF','ALT','QUAL','INFO','format', 'filter',headerline[9].lower(), headerline[10][0:-1].lower(),
+        indel_table = pd.DataFrame(index=[0],columns=['contig', 'position','ID','REF','ALT','QUAL','INFO','format', 'filter',headerline[9], headerline[10],
                                                       't_depth','t_alt_count','t_ref_count','n_alt_count','n_depth','n_ref_count','tau','f_acs','Chromosome','genomic_coord_x'])
     else:
         indel_table['t_depth'] = t_alt_count + t_ref_count


### PR DESCRIPTION
The VCF spec demands that the samples' column names match entries in the header (e.g. if `##normal_sample=MY_NORMAL` is present in the header, then the column for the normal should be named `MY_NORMAL`.)

Previously, deTiN would break on otherwise valid indel VCFs. This fixes that. As a bonus, the deTiN output should be easier to merge with the input VCF, since the VCF column names are preserved.